### PR TITLE
Line 43 of cli.pawls.preprocessors.tesseract in extract_page_tokens()…

### DIFF
--- a/cli/pawls/preprocessors/tesseract.py
+++ b/cli/pawls/preprocessors/tesseract.py
@@ -40,7 +40,7 @@ def extract_page_tokens(
                     gp["width"].max(),
                     gp["height"].max(),
                     gp["conf"].mean(),
-                    gp["text"].str.cat(sep=" "),
+                    gp["text"].astype(str).str.cat(sep=" "),
                 ]
             )
         )


### PR DESCRIPTION
… fails when the underlying text datatype is not actually text. I assume this is rare but is dependent on the original source PDF authoring tool. I have a pdf where once page only has a number on it and it appears the data type that is extracted to the dataframe is float64. This fails with the extract_page_tokens() function as written. Added .astype(str) to line 43 to force conversion to string, which should cover these kinds of corner cases. Working for me at least on the pdf that was crashingt the parser.